### PR TITLE
Fix nix setup for OSX High Sierra

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -5,9 +5,12 @@ mkDerivation {
   pname = "sturdy-lib";
   version = "0.1.0.0";
   src = ./.;
-  libraryHaskellDepends = [
+  libraryHaskellDepends = (if pkgs.stdenv.isDarwin then [
     base containers hashable mtl text unordered-containers
-  ];
+    pkgs.darwin.apple_sdk.frameworks.Cocoa
+  ] else [
+    base containers hashable mtl text unordered-containers
+  ]);
   testHaskellDepends = [ base hspec text unordered-containers ];
   license = stdenv.lib.licenses.bsd3;
 }


### PR DESCRIPTION
As mentioned in [nixpkgs #27170](https://github.com/NixOS/nixpkgs/issues/27170), nix generates warnings when ran. This is fixed for most OS's but for OSX High Sierra.

Running tests with this setup hides these warnings, decreases startup time and gives the same test results.