### PR TITLE
Add continuations to read and lookup

### DIFF
--- a/lib/src/Control/Arrow/Environment.hs
+++ b/lib/src/Control/Arrow/Environment.hs
@@ -10,7 +10,7 @@ import Control.Arrow.Utils
 -- | Arrow-based interface for interacting with environments.
 class Arrow c => ArrowEnv var val env c | c -> var, c -> val, c -> env where
   -- | Lookup a variable in the current environment.
-  lookup :: c var val
+  lookup :: c (val,a) val -> c a val -> c (var,a) val
   -- | Retrieve the current environment.
   getEnv :: c () env
   -- | Extend an environment with a binding.

--- a/lib/src/Control/Arrow/Store.hs
+++ b/lib/src/Control/Arrow/Store.hs
@@ -11,6 +11,6 @@ import Control.Arrow
 -- | Arrow-based interface to describe computations that modify a store.
 class Arrow c => ArrowStore var val lab c | c -> var, c -> val where
   -- | Reads a value from the store. Fails if the binding is not in the current store.
-  read :: c (var,lab) val
+  read :: c (val,x) val -> c x val -> c ((var,lab),x) val
   -- | Writes a value to the store.
   write :: c (var,val,lab) ()

--- a/lib/src/Control/Arrow/Transformer/Abstract/Completion.hs
+++ b/lib/src/Control/Arrow/Transformer/Abstract/Completion.hs
@@ -63,14 +63,14 @@ instance (ArrowChoice c, ArrowReader r c) => ArrowReader r (Completion c) where
   localA (Completion f) = Completion (localA f)
 
 instance (ArrowChoice c, ArrowEnv x y env c) => ArrowEnv x y env (Completion c) where
-  lookup = lift lookup
+  lookup (Completion f) = Completion (lookup f)
   getEnv = lift getEnv
   extendEnv = lift extendEnv
   localEnv (Completion f) = Completion (localEnv f)
 
 instance (ArrowChoice c, ArrowExcept x (FreeCompletion y) e c) => ArrowExcept x y e (Completion c) where
-  tryCatchA (Completion f) (Completion g) = Completion $ tryCatchA f g 
-  finally (Completion f) (Completion g) = Completion $ finally f g 
+  tryCatchA (Completion f) (Completion g) = Completion $ tryCatchA f g
+  finally (Completion f) (Completion g) = Completion $ finally f g
 
 instance ArrowChoice c => ArrowDeduplicate (Completion c) where
   dedupA = returnA

--- a/lib/src/Control/Arrow/Transformer/Abstract/HandleExcept.hs
+++ b/lib/src/Control/Arrow/Transformer/Abstract/HandleExcept.hs
@@ -73,7 +73,7 @@ instance (Complete e, ArrowJoin c, ArrowChoice c, ArrowReader r c) => ArrowReade
   localA (Except f) = Except (localA f)
 
 instance (Complete e, ArrowJoin c, ArrowChoice c, ArrowEnv x y env c) => ArrowEnv x y env (Except e c) where
-  lookup = lift lookup
+  lookup (Except f) (Except g) = Except (lookup f g)
   getEnv = lift getEnv
   extendEnv = lift extendEnv
   localEnv (Except f) = Except (localEnv f)

--- a/lib/src/Control/Arrow/Transformer/Abstract/LiveVariables.hs
+++ b/lib/src/Control/Arrow/Transformer/Abstract/LiveVariables.hs
@@ -75,9 +75,9 @@ runLiveVariables :: LiveVariables v c x y -> c (LiveVars v,x) y
 runLiveVariables (LiveVariables f) = runWriter (runState f)
 
 instance (Identifiable var, ArrowStore var val lab c) => ArrowStore var val lab (LiveVariables var c) where
-  read = LiveVariables $ proc (x,l) -> do
+  read (LiveVariables f) (LiveVariables g) = LiveVariables $ proc (x,l) -> do
     effect live -< x
-    read -< (x,l)
+    read f g -< (x,l)
   write = LiveVariables $ proc (x,v,l) -> do
     modifyA' dead -< x
     write -< (x,v,l)
@@ -104,4 +104,3 @@ deriving instance LowerBounded (c (LiveVarsTrans v,x) (LiveVarsTrans v,(LiveVars
 deriving instance Complete (c (LiveVarsTrans v,x) (LiveVarsTrans v,(LiveVarsTrans v,y))) => Complete (LiveVariables v c x y)
 deriving instance CoComplete (c (LiveVarsTrans v,x) (LiveVarsTrans v,(LiveVarsTrans v,y))) => CoComplete (LiveVariables v c x y)
 deriving instance UpperBounded (c (LiveVarsTrans v,x) (LiveVarsTrans v,(LiveVarsTrans v,y))) => UpperBounded (LiveVariables v c x y)
-

--- a/lib/src/Control/Arrow/Transformer/Abstract/Powerset.hs
+++ b/lib/src/Control/Arrow/Transformer/Abstract/Powerset.hs
@@ -67,10 +67,10 @@ instance (ArrowChoice c, ArrowFail e c) => ArrowFail e (Powerset c) where
   failA = lift failA
 
 instance (ArrowChoice c, ArrowEnv x y env c) => ArrowEnv x y env (Powerset c) where
-  lookup = lift lookup
+  lookup (Powerset f) (Powerset g) = Powerset (lookup f g)
   getEnv = lift getEnv
   extendEnv = lift extendEnv
-  localEnv (Powerset f) = Powerset $ localEnv f
+  localEnv (Powerset f) = Powerset (localEnv f)
 
 instance (ArrowChoice c, ArrowDeduplicate c) => ArrowDeduplicate (Powerset c) where
   dedupA (Powerset f) = Powerset $ proc x -> do

--- a/lib/src/Control/Arrow/Transformer/Abstract/PropagateExcept.hs
+++ b/lib/src/Control/Arrow/Transformer/Abstract/PropagateExcept.hs
@@ -69,7 +69,7 @@ instance (ArrowChoice c, ArrowReader r c) => ArrowReader r (Except e c) where
   localA (Except f) = Except (localA f)
 
 instance (ArrowChoice c, ArrowEnv x y env c) => ArrowEnv x y env (Except e c) where
-  lookup = lift lookup
+  lookup (Except f) (Except g) = Except (lookup f g)
   getEnv = lift getEnv
   extendEnv = lift extendEnv
   localEnv (Except f) = Except (localEnv f)
@@ -78,7 +78,7 @@ type instance Fix x y (Except e c) = Except e (Fix x (Error e y) c)
 instance (ArrowChoice c, ArrowFix x (Error e y) c) => ArrowFix x y (Except e c) where
   fixA f = Except (fixA (runExcept . f . Except))
 
-{- 
+{-
 There is no `ArrowExcept` instance for `Except` on purpose. This is how it would look like.
 
 instance (ArrowChoice c, UpperBounded e, Complete (c (y,(x,e)) (Error e y))) => ArrowExcept x y e (Except e c) where

--- a/lib/src/Control/Arrow/Transformer/Abstract/ReachingDefinitions.hs
+++ b/lib/src/Control/Arrow/Transformer/Abstract/ReachingDefinitions.hs
@@ -49,7 +49,7 @@ runReachingDefs' (ReachingDefs f) = f
 
 instance (Identifiable var, Identifiable lab, ArrowStore var val lab c)
   => ArrowStore var val lab (ReachingDefinitions var lab c) where
-  read = lift read 
+  read (ReachingDefinitions f) (ReachingDefinitions g) = ReachingDefinitions $ read f g
   write = ReachingDefinitions $ proc (x,v,l) -> do
     record (\(x,l) (defs) -> H.insert (x,Just l) (H.filter (\(y,_) -> x /= y) defs)) -< (x,l)
     write -< (x,v,l)

--- a/lib/src/Control/Arrow/Transformer/BackwardState.hs
+++ b/lib/src/Control/Arrow/Transformer/BackwardState.hs
@@ -80,13 +80,13 @@ instance (ArrowLoop c, ArrowReader r c) => ArrowReader r (State s c) where
   localA (State f) = State $ (\(s,(r,x)) -> (r,(s,x))) ^>> localA f
 
 instance (ArrowLoop c, ArrowEnv x y env c) => ArrowEnv x y env (State r c) where
-  lookup = lift lookup
+  lookup (State f) (State g) = State (lookup f g)
   getEnv = lift getEnv
   extendEnv = lift extendEnv
   localEnv (State f) = State ((\(r,(env,a)) -> (env,(r,a))) ^>> localEnv f)
 
 instance (ArrowLoop c, ArrowStore var val lab c) => ArrowStore var val lab (State r c) where
-  read = lift read
+  read (State f) (State g) = State (read f g)
   write = lift write
 
 type instance Fix x y (State s c) = State s (Fix (s,x) (s,y) c)

--- a/lib/src/Control/Arrow/Transformer/Concrete/Environment.hs
+++ b/lib/src/Control/Arrow/Transformer/Concrete/Environment.hs
@@ -18,8 +18,10 @@ import qualified Data.Concrete.Environment as E
 import           Control.Category
 
 import           Control.Arrow
+import           Control.Arrow.Const
 import           Control.Arrow.Transformer.Reader
 import           Control.Arrow.Reader
+import           Control.Arrow.Store
 import           Control.Arrow.State
 import           Control.Arrow.Fail
 import           Control.Arrow.Lift
@@ -35,13 +37,12 @@ newtype Environment var val c x y = Environment (Reader (Env var val) c x y)
 runEnvironment :: (Arrow c, Eq var, Hashable var) => Environment var val c x y -> c ([(var,val)],x) y
 runEnvironment (Environment (Reader f)) = first E.fromList ^>> f
 
-instance (Show var, Identifiable var, ArrowChoice c, ArrowFail String c) =>
+instance (Show var, Identifiable var, ArrowChoice c) =>
   ArrowEnv var val (Env var val) (Environment var val c) where
-  lookup = proc x -> do
-    env <- getEnv -< ()
-    case E.lookup x env of
-      Just y -> returnA -< y
-      Nothing -> failA -< printf "Variable %s not bound" (show x)
+  lookup (Environment (Reader f)) (Environment (Reader g)) =
+    Environment $ Reader $ proc (env,(var,x)) -> case E.lookup var env of
+      Just val -> f -< (env,(val,x))
+      Nothing -> g -< (env,x)
   getEnv = Environment askA
   extendEnv = arr $ \(x,y,env) -> E.insert x y env
   localEnv (Environment f) = Environment (localA f)
@@ -57,9 +58,11 @@ deriving instance Arrow c => Category (Environment var val c)
 deriving instance Arrow c => Arrow (Environment var val c)
 deriving instance ArrowLift (Environment var val)
 deriving instance ArrowChoice c => ArrowChoice (Environment var val c)
+deriving instance ArrowStore var val lab c => ArrowStore var val lab (Environment var' val' c)
 deriving instance ArrowState s c => ArrowState s (Environment var val c)
 deriving instance ArrowFail e c => ArrowFail e (Environment var val c)
 deriving instance ArrowExcept (Env var val,x) y e c => ArrowExcept x y e (Environment var val c)
+deriving instance ArrowConst r c => ArrowConst r (Environment var val c)
 
 type instance Fix x y (Environment var val c) = Environment var val (Fix (Env var val,x) y c)
 deriving instance ArrowFix (Env var val,x) y c => ArrowFix x y (Environment var val c)

--- a/lib/src/Control/Arrow/Transformer/Const.hs
+++ b/lib/src/Control/Arrow/Transformer/Const.hs
@@ -23,7 +23,8 @@ import Control.Arrow.Store
 import Control.Arrow.Const
 import Control.Arrow.Writer
 import Control.Arrow.Transformer.Static
-    
+import Control.Arrow.Abstract.Join
+
 import Data.Order
 
 -- | Passes along constant data.
@@ -42,6 +43,7 @@ instance Arrow c => ArrowConst r (Const r c) where
 instance ArrowApply c => ArrowApply (Const r c) where
   app = Const $ Static $ \r -> (\(Const (Static f),x) -> (f r,x)) ^>> app
 
+deriving instance ArrowJoin c => ArrowJoin (Const r c)
 deriving instance ArrowLift (Const r)
 deriving instance Arrow c => Category (Const r c)
 deriving instance Arrow c => Arrow (Const r c)

--- a/lib/src/Control/Arrow/Transformer/Static.hs
+++ b/lib/src/Control/Arrow/Transformer/Static.hs
@@ -67,13 +67,13 @@ instance (Applicative f, ArrowExcept x y e c) => ArrowExcept x y e (Static f c) 
   finally (Static f) (Static g) = Static $ finally <$> f <*> g
 
 instance (Applicative f, ArrowEnv x y env c) => ArrowEnv x y env (Static f c) where
-  lookup = lift lookup
+  lookup (Static f) (Static g) = Static $ lookup <$> f <*> g
   getEnv = lift getEnv
   extendEnv = lift extendEnv
   localEnv (Static f) = Static $ localEnv <$> f
 
 instance (Applicative f, ArrowStore var val lab c) => ArrowStore var val lab (Static f c) where
-  read = lift read
+  read (Static f) (Static g) = Static $ read <$> f <*> g
   write = lift write
 
 instance (Applicative f, ArrowLoop c) => ArrowLoop (Static f c) where
@@ -87,4 +87,3 @@ deriving instance Complete (f (c x y)) => Complete (Static f c x y)
 deriving instance CoComplete (f (c x y)) => CoComplete (Static f c x y)
 deriving instance UpperBounded (f (c x y)) => UpperBounded (Static f c x y)
 deriving instance LowerBounded (f (c x y)) => LowerBounded (Static f c x y)
-         

--- a/lib/src/Control/Arrow/Transformer/Writer.hs
+++ b/lib/src/Control/Arrow/Transformer/Writer.hs
@@ -73,13 +73,14 @@ instance (Monoid w, ArrowReader r c) => ArrowReader r (Writer w c) where
   localA (Writer f) = Writer (localA f)
 
 instance (Monoid w, ArrowEnv x y env c) => ArrowEnv x y env (Writer w c) where
-  lookup = lift lookup
+  lookup (Writer f) (Writer g) = Writer (lookup f g)
   getEnv = lift getEnv
   extendEnv = lift extendEnv
   localEnv (Writer f) = Writer (localEnv f)
 
 instance (Monoid w, ArrowStore var val lab c) => ArrowStore var val lab (Writer w c) where
-  read = lift read
+  -- read (Writer f) (Writer g) = Writer (read f g)
+  read f g = read f g
   write = lift write
 
 type instance Fix x y (Writer w c) = Writer w (Fix x (w,y) c)

--- a/lib/src/Data/Order.hs
+++ b/lib/src/Data/Order.hs
@@ -169,12 +169,21 @@ instance PreOrd Double where
   (≈) = (==)
 
 instance PreOrd a => PreOrd (Maybe a) where
-  Just x ⊑ Just y = x ⊑ y 
+  Just x ⊑ Just y = x ⊑ y
   Nothing ⊑ Nothing = True
   _ ⊑ _ = False
-  Just x ≈ Just y = x ≈ y 
+  Just x ≈ Just y = x ≈ y
   Nothing ≈ Nothing = True
   _ ≈ _ = False
+
+instance Complete a => Complete (Maybe a) where
+  Just x ⊔ Just y = Just $ x ⊔ y
+  Just x ⊔ _ = Just x
+  _ ⊔ Just x = Just x
+  Nothing ⊔ Nothing = Nothing
+
+instance PreOrd a => LowerBounded (Maybe a) where
+  bottom = Nothing
 
 instance PreOrd a => LowerBounded (Set a) where
   bottom = S.empty


### PR DESCRIPTION
This PR adds continuations to
- `read` method of `ArrowStore` typeclass
- `lookup` method of `Environment` typeclass

These continuations do not yet typecheck.